### PR TITLE
Added forwardPortRange feature

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/test-workspace/README.md
+++ b/test-workspace/README.md
@@ -4,6 +4,15 @@ Demonstrates the Remote UDP Tunnel extension in action.
 
 Contains a small UDP echo server and test client for experimentation.
 
+```
+# In remote environment
+node server.js 9090 9091 ...
+
+# On UI host
+node client.js 9090
+node client.js 9091
+```
+
 `test-proxies.js` runs our upd proxy machinery without vscode.
 
 Performance testing can be done with `iperf3`. Eg.

--- a/test-workspace/server.js
+++ b/test-workspace/server.js
@@ -34,11 +34,14 @@ function serve(port) {
 }
 
 function main() {
-  let port = 0;
+  let ports = [0];
   if (process.argv.length > 2) {
-    port = parseInt(process.argv[2]);
+    ports = [];
+    for (let i = 2; i < process.argv.length; ++i) {
+      ports.push(parseInt(process.argv[i]));
+    }
   }
-  serve(port);
+  ports.forEach(serve);
 }
 
 module.exports = { serve };

--- a/workspace-extension/README.md
+++ b/workspace-extension/README.md
@@ -30,7 +30,7 @@ If, as I did, you find yourself working with UDP servers on ephemeral / dynamic 
 - The proxy decoder has a small chance of fragmenting some UDP packets. I have not observed this in practice so far.
 - The "Time to First Byte" for a new client sending packets can be over a second as the VS Code TCP tunnel itself has a very slow handshake to complete on each new connection.
 - The extension does not currently auto-detect open UDP ports and forward them, as the TCP version built in to vscode does. I may add this feature.
-- This extension won't work with vscode running in browser-sandboxed scenarios (such as codespaces) where the extension cannot open a UDP port for you to access.
+- This extension won't work with vscode running in browser-sandboxed scenarios (such as ["Visual Studio Code for the Web"](https://vscode.dev/)) where the extension cannot open a UDP port for you to access.
 
 ## Extension Settings
 
@@ -41,3 +41,7 @@ This extension exposes no settings.
 ### 0.0.1
 
 Alpha release. Good Luck, Have Fun!
+
+### 0.0.5
+
+**Feature:** Open multiple ports with a single command. Multiple ports can be specified as a list (eg. "2001,2002,2003"), a range (eg. "2001-2003"), or a count eg. ("2001x3"). Thanks to [@Danielv123](https://github.com/Danielv123).

--- a/workspace-extension/package.json
+++ b/workspace-extension/package.json
@@ -25,7 +25,6 @@
 	"activationEvents": [
 		"onStartupFinished",
 		"onCommand:remote-udp-tunnel.forwardPort",
-		"onCommand:remote-udp-tunnel.forwardPortRange",
 		"onCommand:remote-udp-tunnel.stopForwardingPort"
 	],
 	"main": "./out/extension.js",
@@ -34,11 +33,6 @@
 			{
 				"command": "remote-udp-tunnel.forwardPort",
 				"title": "Forward a Port",
-				"category": "Remote UDP Tunnel"
-			},
-			{
-				"command": "remote-udp-tunnel.forwardPortRange",
-				"title": "Forward range of ports",
 				"category": "Remote UDP Tunnel"
 			},
 			{
@@ -60,10 +54,6 @@
 			"commandPalette": [
 				{
 					"command": "remote-udp-tunnel.forwardPort",
-					"when": "remoteName && remoteName !== ''"
-				},
-				{
-					"command": "remote-udp-tunnel.forwardPortRange",
 					"when": "remoteName && remoteName !== ''"
 				},
 				{

--- a/workspace-extension/package.json
+++ b/workspace-extension/package.json
@@ -25,6 +25,7 @@
 	"activationEvents": [
 		"onStartupFinished",
 		"onCommand:remote-udp-tunnel.forwardPort",
+		"onCommand:remote-udp-tunnel.forwardPortRange",
 		"onCommand:remote-udp-tunnel.stopForwardingPort"
 	],
 	"main": "./out/extension.js",
@@ -33,6 +34,11 @@
 			{
 				"command": "remote-udp-tunnel.forwardPort",
 				"title": "Forward a Port",
+				"category": "Remote UDP Tunnel"
+			},
+			{
+				"command": "remote-udp-tunnel.forwardPortRange",
+				"title": "Forward range of ports",
 				"category": "Remote UDP Tunnel"
 			},
 			{
@@ -54,6 +60,10 @@
 			"commandPalette": [
 				{
 					"command": "remote-udp-tunnel.forwardPort",
+					"when": "remoteName && remoteName !== ''"
+				},
+				{
+					"command": "remote-udp-tunnel.forwardPortRange",
 					"when": "remoteName && remoteName !== ''"
 				},
 				{


### PR DESCRIPTION
To forward a range of ports, open the forward port range feature in the command palette and write [startPort],[count], ex 8080,4

![Forward range of ports](https://i.imgur.com/4ewxE2g.png)

![Specify range and count](https://i.imgur.com/86gWBn9.png)

![Ports get forwarded](https://i.imgur.com/0wjtfPl.png)

resolves #1 